### PR TITLE
Add info for Just Enough AWS talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Put your presentations and derivative works here
 ## 2011-11-02
 Brian Maddy: Functional Relational Programming
 Slides: https://github.com/bmaddy/presentations/tree/master/2011-functional-relational-programming
+
+## 2018-02-13
+Evan Niessen-Derry: Just Enough AWS
+Code: https://github.com/futuro/just-enough-aws


### PR DESCRIPTION
This calls out who gave the talk (me), and where the code lives.

Fixes #3 